### PR TITLE
Extends EEPROM Service Life

### DIFF
--- a/Code and Verification - v1/LaserPowerMonitor/EEPROMAnything.h
+++ b/Code and Verification - v1/LaserPowerMonitor/EEPROMAnything.h
@@ -4,12 +4,24 @@
 //#include <WProgram.h>  // for type definitions
 #include <Arduino.h>  // for type definitions
 
+// Kent - added round robin methods and configuration items to help minimize eeprom wear
+
+//this is already configured to the size of the 'config_t' struct
+#define ROUND_ROBIN_DATA_TYPE_BYTES 4+4+4+2
+
+//this is configured to ignore address 0 which has already seen a lot of action
+#define ROUND_ROBIN_MIN_EEPROM_ADDR 1 * ROUND_ROBIN_DATA_TYPE_BYTES
+
+//define the number of slots we will distribute the eeprom IO out accross
+//this setting will still comfortably not exceed the atmega168 512 byte limitations (you can expand this if your chip allows 1K)
+#define ROUND_ROBIN_MAX_EEPROM_ADDR 30 * ROUND_ROBIN_DATA_TYPE_BYTES
+
 template <class T> int EEPROM_writeAnything(int ee, const T& value)
 {
     const byte* p = (const byte*)(const void*)&value;
     int i;
     for (i = 0; i < sizeof(value); i++)
-	  EEPROM.write(ee++, *p++);
+        EEPROM.write(ee++, *p++);
     return i;
 }
 
@@ -18,6 +30,83 @@ template <class T> int EEPROM_readAnything(int ee, T& value)
     byte* p = (byte*)(void*)&value;
     int i;
     for (i = 0; i < sizeof(value); i++)
-	  *p++ = EEPROM.read(ee++);
+        *p++ = EEPROM.read(ee++);
     return i;
 }
+
+//zero out the entire round robin window
+void ROUND_ROBIN_EEPROM_ZeroOutWindow()
+{
+    byte eeData[ROUND_ROBIN_DATA_TYPE_BYTES];
+
+    for (int addr = ROUND_ROBIN_MIN_EEPROM_ADDR; addr <= ROUND_ROBIN_MAX_EEPROM_ADDR; addr += ROUND_ROBIN_DATA_TYPE_BYTES)
+    {
+        EEPROM_readAnything(addr, eeData);
+        byte testByte = 0x00;
+        for (int b = 0; b < ROUND_ROBIN_DATA_TYPE_BYTES; b++)
+        {
+            //if we find a byte address with data in it, set it to 0x00
+            if (eeData[b] != 0x00)
+                EEPROM.write(addr + b, 0x00);
+        }
+
+    }
+
+}
+
+//returns the address that is currently being used in the round robin window
+int ROUND_ROBIN_EEPROM_GetAddressOfData()
+{
+    byte eeData[ROUND_ROBIN_DATA_TYPE_BYTES];
+
+    for (int addr = ROUND_ROBIN_MIN_EEPROM_ADDR; addr <= ROUND_ROBIN_MAX_EEPROM_ADDR; addr += ROUND_ROBIN_DATA_TYPE_BYTES)
+    {
+        EEPROM_readAnything(addr, eeData);
+        for (int b = 0; b < ROUND_ROBIN_DATA_TYPE_BYTES; b++)
+        {
+            //if we find the address with data in it, return that address and break out of the loop
+            if (eeData[b] != 0x00)
+                return addr;
+        }
+
+    }
+    //if we get to this line we failed to find data in our round robin window (or the data was actually 0L)
+    //in this case we start at the beginning of the window again
+    return ROUND_ROBIN_MIN_EEPROM_ADDR;
+}
+
+//find the value stored in the round robin window and assign it to 'value'
+template <class T> int ROUND_ROBIN_EEPROM_read(T& value)
+{
+    int ee = ROUND_ROBIN_EEPROM_GetAddressOfData();
+    int newAddress = ee;
+    byte* p = (byte*)(void*)&value;
+    int i;
+    for (i = 0; i < sizeof(value); i++)
+        *p++ = EEPROM.read(ee++);
+    return newAddress;
+}
+
+//write the 'value' to the round robin window and manage clean up from the previous write
+template <class T> int ROUND_ROBIN_EEPROM_write(T& value)
+{
+    //this will be the eeprom address of the last round robin value recorded
+    int eeLastAddress = ROUND_ROBIN_EEPROM_GetAddressOfData();
+
+    //to spread things out the next block in our round robin window will be used next
+    //if we are at the end of the defined window, start again at the first byte of our window
+    int ee = (eeLastAddress == ROUND_ROBIN_MAX_EEPROM_ADDR) ? ROUND_ROBIN_MIN_EEPROM_ADDR : eeLastAddress + sizeof(value);
+    int newAddress = ee;
+    const byte* p = (const byte*)(const void*)&value;
+    int i;
+    for (i = 0; i < sizeof(value); i++)
+        EEPROM.write(ee++, *p++);
+
+    //now clean up the data in the previously used slot so it won't be confused with live data on the next read request
+    for (int l = 0; l < sizeof(value); l++)
+        EEPROM.write(eeLastAddress++, 0x00);
+    return newAddress;
+}
+
+
+

--- a/Code and Verification - v1/LaserPowerMonitor/LaserPowerMonitor.pde
+++ b/Code and Verification - v1/LaserPowerMonitor/LaserPowerMonitor.pde
@@ -26,6 +26,8 @@
  * button input for reset -> make on Nano D6, "pin 6"
  */
 
+ // Kent - altered eeprom read and write calls to extend eeprom life
+
 #define MAX_OUT_CHARS 16  //max nbr of characters to be sent on any one serial command
 
 // initialize the library with the numbers of the interface pins
@@ -90,7 +92,9 @@ void setup() {
   pinMode(TestOutPin2, OUTPUT);
   
   Serial.begin(9600);
-  EEPROM_readAnything(0, laserTime);
+  //EEPROM_readAnything(0, laserTime);
+  //ROUND_ROBIN_EEPROM_ZeroOutWindow();  //use this if you need to clean all the eeprom possitions withing the window defined in the header
+  int addr = ROUND_ROBIN_EEPROM_read(laserTime);
   tubeMillis = laserTime.seconds*1000;
   userMillis = laserTime.uSeconds*1000;
   
@@ -98,8 +102,9 @@ void setup() {
   if ( laserTime.thisVersion == 0 ) {
 	laserTime.thisVersion = ThisCurrentVersion;
 	laserTime.EEPROMwriteCount = laserTime.EEPROMwriteCount + 1;
-	EEPROM_writeAnything(0, laserTime);
-    }
+	//EEPROM_writeAnything(0, laserTime);
+	addr = ROUND_ROBIN_EEPROM_write(laserTime);
+  }
   
   
   // Briefly show Arduino status
@@ -129,7 +134,10 @@ void setup() {
 //  BacklightColor ( 0, 0, 255);
 
   
-  Serial.println("Values stored in EEPROM");
+  Serial.print("Values stored in EEPROM address ");
+  Serial.println(addr);
+
+
   Serial.print("  laserTime.seconds ie tube: ");
   Serial.println(laserTime.seconds);
   
@@ -238,9 +246,16 @@ void loop() {
         laserTime.uSeconds = userMillis/1000;
 		laserTime.EEPROMwriteCount = laserTime.EEPROMwriteCount + 1;
 		laserTime.thisVersion = ThisCurrentVersion;
-        EEPROM_writeAnything(0, laserTime);
-        lastWriteToEEPROMMillis = millis();
+        //EEPROM_writeAnything(0, laserTime);
+		int addr = ROUND_ROBIN_EEPROM_write(laserTime);
+
+		lastWriteToEEPROMMillis = millis();
+        
         Serial.println("User hit reset & Wrote to EEPROM");
+
+		Serial.print("  EEPROM address: ");
+		Serial.println(addr);
+
 		Serial.print("  laserTime.seconds ie tube: ");
 		Serial.println(laserTime.seconds);
   
@@ -274,7 +289,8 @@ void loop() {
 
   // Only write to EEPROM if the current value is more than 5 minutes from the previous EEPROM value
   // to reduce the number of writes to EEPROM, since it is only good for ~ 100,000 writes
-  EEPROM_readAnything(0, laserTime);
+  //EEPROM_readAnything(0, laserTime);
+  int addr = ROUND_ROBIN_EEPROM_read(laserTime);
   unsigned long laserSeconds = laserTime.seconds;
   
   // note - it appears that only one of the following If statements is required  
@@ -287,9 +303,14 @@ void loop() {
     laserTime.uSeconds = userMillis/1000;
 	laserTime.EEPROMwriteCount = laserTime.EEPROMwriteCount + 1;
 	laserTime.thisVersion = ThisCurrentVersion;
-    EEPROM_writeAnything(0, laserTime);
+    //EEPROM_writeAnything(0, laserTime);
+	addr = ROUND_ROBIN_EEPROM_write(laserTime);
     lastWriteToEEPROMMillis = millis();
     Serial.println("Wrote to EEPROM - tube has another 5 minutes of use");
+	
+	Serial.print("  EEPROM address: ");
+	Serial.println(addr);
+
 	Serial.print("  laserTime.seconds ie tube: ");
 	Serial.println(laserTime.seconds);
 	
@@ -308,9 +329,15 @@ void loop() {
     laserTime.uSeconds = userMillis/1000;
 	laserTime.EEPROMwriteCount = laserTime.EEPROMwriteCount + 1;
 	laserTime.thisVersion = ThisCurrentVersion;
-	EEPROM_writeAnything(0, laserTime);
+	//this method has been replaced to distribute the eeprom writing accross a wider address space
+	//EEPROM_writeAnything(0, laserTime);
+	addr = ROUND_ROBIN_EEPROM_write(laserTime);
     lastWriteToEEPROMMillis = millis();
     Serial.println("Wrote to EEPROM - value has changed in last 5 minutes");
+	
+	Serial.print("  EEPROM address: ");
+	Serial.println(addr);
+
 	Serial.print("  laserTime.seconds ie tube: ");
 	Serial.println(laserTime.seconds);
 	

--- a/Code and Verification - v1/LaserPowerMonitorZeroEEPROM/EEPROMAnything.h
+++ b/Code and Verification - v1/LaserPowerMonitorZeroEEPROM/EEPROMAnything.h
@@ -4,12 +4,24 @@
 //#include <WProgram.h>  // for type definitions
 #include <Arduino.h>  // for type definitions
 
+// Kent - added round robin methods and configuration items to help minimize eeprom wear
+
+//this is already configured to the size of the 'config_t' struct
+#define ROUND_ROBIN_DATA_TYPE_BYTES 4+4+4+2
+
+//this is configured to ignore address 0 which has already seen a lot of action
+#define ROUND_ROBIN_MIN_EEPROM_ADDR 1 * ROUND_ROBIN_DATA_TYPE_BYTES
+
+//define the number of slots we will distribute the eeprom IO out accross
+//this setting will still comfortably not exceed the atmega168 512 byte limitations (you can expand this if your chip allows 1K)
+#define ROUND_ROBIN_MAX_EEPROM_ADDR 30 * ROUND_ROBIN_DATA_TYPE_BYTES
+
 template <class T> int EEPROM_writeAnything(int ee, const T& value)
 {
     const byte* p = (const byte*)(const void*)&value;
     int i;
     for (i = 0; i < sizeof(value); i++)
-	  EEPROM.write(ee++, *p++);
+        EEPROM.write(ee++, *p++);
     return i;
 }
 
@@ -18,6 +30,83 @@ template <class T> int EEPROM_readAnything(int ee, T& value)
     byte* p = (byte*)(void*)&value;
     int i;
     for (i = 0; i < sizeof(value); i++)
-	  *p++ = EEPROM.read(ee++);
+        *p++ = EEPROM.read(ee++);
     return i;
 }
+
+//zero out the entire round robin window
+void ROUND_ROBIN_EEPROM_ZeroOutWindow()
+{
+    byte eeData[ROUND_ROBIN_DATA_TYPE_BYTES];
+
+    for (int addr = ROUND_ROBIN_MIN_EEPROM_ADDR; addr <= ROUND_ROBIN_MAX_EEPROM_ADDR; addr += ROUND_ROBIN_DATA_TYPE_BYTES)
+    {
+        EEPROM_readAnything(addr, eeData);
+        byte testByte = 0x00;
+        for (int b = 0; b < ROUND_ROBIN_DATA_TYPE_BYTES; b++)
+        {
+            //if we find a byte address with data in it, set it to 0x00
+            if (eeData[b] != 0x00)
+                EEPROM.write(addr + b, 0x00);
+        }
+
+    }
+
+}
+
+//returns the address that is currently being used in the round robin window
+int ROUND_ROBIN_EEPROM_GetAddressOfData()
+{
+    byte eeData[ROUND_ROBIN_DATA_TYPE_BYTES];
+
+    for (int addr = ROUND_ROBIN_MIN_EEPROM_ADDR; addr <= ROUND_ROBIN_MAX_EEPROM_ADDR; addr += ROUND_ROBIN_DATA_TYPE_BYTES)
+    {
+        EEPROM_readAnything(addr, eeData);
+        for (int b = 0; b < ROUND_ROBIN_DATA_TYPE_BYTES; b++)
+        {
+            //if we find the address with data in it, return that address and break out of the loop
+            if (eeData[b] != 0x00)
+                return addr;
+        }
+
+    }
+    //if we get to this line we failed to find data in our round robin window (or the data was actually 0L)
+    //in this case we start at the beginning of the window again
+    return ROUND_ROBIN_MIN_EEPROM_ADDR;
+}
+
+//find the value stored in the round robin window and assign it to 'value'
+template <class T> int ROUND_ROBIN_EEPROM_read(T& value)
+{
+    int ee = ROUND_ROBIN_EEPROM_GetAddressOfData();
+    int newAddress = ee;
+    byte* p = (byte*)(void*)&value;
+    int i;
+    for (i = 0; i < sizeof(value); i++)
+        *p++ = EEPROM.read(ee++);
+    return newAddress;
+}
+
+//write the 'value' to the round robin window and manage clean up from the previous write
+template <class T> int ROUND_ROBIN_EEPROM_write(T& value)
+{
+    //this will be the eeprom address of the last round robin value recorded
+    int eeLastAddress = ROUND_ROBIN_EEPROM_GetAddressOfData();
+
+    //to spread things out the next block in our round robin window will be used next
+    //if we are at the end of the defined window, start again at the first byte of our window
+    int ee = (eeLastAddress == ROUND_ROBIN_MAX_EEPROM_ADDR) ? ROUND_ROBIN_MIN_EEPROM_ADDR : eeLastAddress + sizeof(value);
+    int newAddress = ee;
+    const byte* p = (const byte*)(const void*)&value;
+    int i;
+    for (i = 0; i < sizeof(value); i++)
+        EEPROM.write(ee++, *p++);
+
+    //now clean up the data in the previously used slot so it won't be confused with live data on the next read request
+    for (int l = 0; l < sizeof(value); l++)
+        EEPROM.write(eeLastAddress++, 0x00);
+    return newAddress;
+}
+
+
+

--- a/Code and Verification - v1/LaserPowerMonitorZeroEEPROM/LaserPowerMonitorZeroEEPROM.pde
+++ b/Code and Verification - v1/LaserPowerMonitorZeroEEPROM/LaserPowerMonitorZeroEEPROM.pde
@@ -63,7 +63,10 @@ void setup() {
 	lcd.println("press reset.... ");
 
 	Serial.println("Before Zeroing EEPROM");
-	EEPROM_readAnything(0, laserTime);
+
+	//EEPROM_readAnything(0, laserTime);
+	ROUND_ROBIN_EEPROM_read(laserTime);
+	ROUND_ROBIN_EEPROM_ZeroOutWindow();
   
 	Serial.print("   laserTime.seconds ie tube: ");
 	Serial.println(laserTime.seconds);
@@ -83,8 +86,11 @@ void loop() {
     if (userReset == LOW) {
 
 		Serial.println("Before Zeroing EEPROM");
-		EEPROM_readAnything(0, laserTime);
+		int addr = ROUND_ROBIN_EEPROM_read(laserTime);
   
+		Serial.print("   address: ");
+		Serial.println(addr);
+
 		Serial.print("   laserTime.seconds ie tube: ");
 		Serial.println(laserTime.seconds);
   
@@ -102,10 +108,10 @@ void loop() {
 		laserTime.uSeconds = 0;
 		laserTime.EEPROMwriteCount = laserTime.EEPROMwriteCount + 1;
 		laserTime.thisVersion = 0;
-		EEPROM_writeAnything(0, laserTime);
+		ROUND_ROBIN_EEPROM_write(laserTime);
 
 		Serial.println("After Zeroing EEPROM");	
-		EEPROM_readAnything(0, laserTime);
+		ROUND_ROBIN_EEPROM_read(laserTime);
   
 		Serial.print("   laserTime.seconds ie tube: ");
 		Serial.println(laserTime.seconds);


### PR DESCRIPTION
Hi!  I am a fellow DMS member.

I added round robin methods and configuration items to help minimize eeprom wear.  Most changes are in EEPROMAnything.h.  I adapted the code in the power monitor logic to call these new methods instead.  I am sure you will want to update your upgrade logic to migrate the previous data you were storing in address 0x00.  As it is configured now, (but easily adustable in the header) it will not use the old block but rotate the fresh addresses after that block.
